### PR TITLE
Add serial control for LED pins

### DIFF
--- a/button_sequence.ino
+++ b/button_sequence.ino
@@ -1,6 +1,8 @@
 void updateLeds(int state);
 void handleSerial();
 void printUsage();
+int parsePin(String token);
+bool parseValue(String token, int &val);
 
 bool serialControl = false;  // true = COM port controls LEDs, button disabled
 
@@ -66,50 +68,108 @@ void updateLeds(int state) {
   }
 }
 
+int parsePin(String token) {
+  token.trim();
+  token.toUpperCase();
+  if (token.length() < 2) return -1;
+  char type = token.charAt(0);
+  int num = token.substring(1).toInt();
+  if (type == 'D' && num >= 2 && num <= 9) return num;
+  if (type == 'A' && num >= 0 && num <= 5) return A0 + num;
+  return -1;
+}
+
+bool parseValue(String token, int &val) {
+  token.trim();
+  token.toUpperCase();
+  if (token == "HIGH" || token == "H") {
+    val = HIGH;
+    return true;
+  }
+  if (token == "LOW" || token == "L") {
+    val = LOW;
+    return true;
+  }
+  return false;
+}
+
 void printUsage() {
-  Serial.println(F("Commands:"));
-  Serial.println(F("  CONTROL ON  - enable serial control"));
-  Serial.println(F("  CONTROL OFF - disable serial control"));
-  Serial.println(F("  D3 HIGH/LOW"));
-  Serial.println(F("  D4 HIGH/LOW"));
-  Serial.println(F("  D5 HIGH/LOW"));
-  Serial.println(F("  STATUS - report pin states"));
+  Serial.println(F("========== Arduino USB GPIO Control =========="));
+  Serial.println(F("Command examples:"));
+  Serial.println(F("Set pin HIGH:    SET D3 HIGH  (S D3 H)"));
+  Serial.println(F("Set pin LOW:     SET D3 LOW   (S D3 L)"));
+  Serial.println(F("Read single pin: READ D3      (R D3)"));
+  Serial.println(F("Read all pins:   READ ALL     (R A)"));
+  Serial.println(F("Toggle control:  CONTROL ON/OFF"));
+  Serial.println(F("Supported pins:  D2~D9, A0~A5"));
+  Serial.println(F("================================================"));
 }
 
 void handleSerial() {
-  if (Serial.available()) {
-    String cmd = Serial.readStringUntil('\n');
-    cmd.trim();
-    cmd.toUpperCase();
+  if (!Serial.available()) return;
 
-    if (cmd == "STATUS") {
+  String cmd = Serial.readStringUntil('\n');
+  cmd.trim();
+  cmd.toUpperCase();
+
+  if (cmd == "CONTROL ON") {
+    serialControl = true;
+    Serial.println(F("Serial control enabled"));
+    return;
+  }
+  if (cmd == "CONTROL OFF") {
+    serialControl = false;
+    Serial.println(F("Serial control disabled"));
+    return;
+  }
+
+  if (cmd == "STATUS") {
+    cmd = "READ ALL";
+  }
+
+  if (cmd.startsWith("SET ") || cmd.startsWith("S ")) {
+    if (!serialControl) {
+      Serial.println(F("Serial control disabled"));
+      return;
+    }
+    int idx = cmd.startsWith("SET ") ? 4 : 2;
+    String rest = cmd.substring(idx);
+    rest.trim();
+    int space = rest.indexOf(' ');
+    if (space > 0) {
+      String pinStr = rest.substring(0, space);
+      String valStr = rest.substring(space + 1);
+      int pin = parsePin(pinStr);
+      int val;
+      if (pin != -1 && parseValue(valStr, val)) {
+        pinMode(pin, OUTPUT);
+        digitalWrite(pin, val);
+        Serial.print(pinStr);
+        Serial.print('=');
+        Serial.println(val == HIGH ? F("HIGH") : F("LOW"));
+      }
+    }
+    return;
+  }
+
+  if (cmd.startsWith("READ ") || cmd.startsWith("R ")) {
+    int idx = cmd.startsWith("READ ") ? 5 : 2;
+    String rest = cmd.substring(idx);
+    rest.trim();
+    if (rest == "ALL" || rest == "A") {
       Serial.print("D3=");
       Serial.print(digitalRead(ledPins[0]) ? "HIGH" : "LOW");
       Serial.print(" D4=");
       Serial.print(digitalRead(ledPins[1]) ? "HIGH" : "LOW");
       Serial.print(" D5=");
       Serial.println(digitalRead(ledPins[2]) ? "HIGH" : "LOW");
-    } else if (cmd == "CONTROL ON") {
-      serialControl = true;
-      Serial.println(F("Serial control enabled"));
-    } else if (cmd == "CONTROL OFF") {
-      serialControl = false;
-      Serial.println(F("Serial control disabled"));
-    } else if (serialControl && cmd.startsWith("D3 ")) {
-      String val = cmd.substring(3);
-      val.trim();
-      if (val == "HIGH") digitalWrite(ledPins[0], HIGH);
-      else if (val == "LOW") digitalWrite(ledPins[0], LOW);
-    } else if (serialControl && cmd.startsWith("D4 ")) {
-      String val = cmd.substring(3);
-      val.trim();
-      if (val == "HIGH") digitalWrite(ledPins[1], HIGH);
-      else if (val == "LOW") digitalWrite(ledPins[1], LOW);
-    } else if (serialControl && cmd.startsWith("D5 ")) {
-      String val = cmd.substring(3);
-      val.trim();
-      if (val == "HIGH") digitalWrite(ledPins[2], HIGH);
-      else if (val == "LOW") digitalWrite(ledPins[2], LOW);
+    } else {
+      int pin = parsePin(rest);
+      if (pin != -1) {
+        Serial.print(rest);
+        Serial.print('=');
+        Serial.println(digitalRead(pin) ? F("HIGH") : F("LOW"));
+      }
     }
   }
 }

--- a/button_sequence.ino
+++ b/button_sequence.ino
@@ -2,6 +2,8 @@ void updateLeds(int state);
 void handleSerial();
 void printUsage();
 
+bool serialControl = false;  // true = COM port controls LEDs, button disabled
+
 const int buttonPin = 2;
 const int ledPins[] = {3, 4, 5};
 
@@ -19,20 +21,22 @@ void setup() {
 }
 
 void loop() {
-  bool reading = digitalRead(buttonPin);
+  if (!serialControl) {
+    bool reading = digitalRead(buttonPin);
 
-  // detect button press (transition from HIGH to LOW)
-  if (lastButtonState == HIGH && reading == LOW) {
-    // simple debounce delay
-    delay(50);
-    reading = digitalRead(buttonPin);
-    if (reading == LOW) {
-      currentState = (currentState + 1) % 4;  // cycle states 0..3
-      updateLeds(currentState);
+    // detect button press (transition from HIGH to LOW)
+    if (lastButtonState == HIGH && reading == LOW) {
+      // simple debounce delay
+      delay(50);
+      reading = digitalRead(buttonPin);
+      if (reading == LOW) {
+        currentState = (currentState + 1) % 4;  // cycle states 0..3
+        updateLeds(currentState);
+      }
     }
-  }
 
-  lastButtonState = reading;
+    lastButtonState = reading;
+  }
 
   handleSerial();
 }
@@ -64,6 +68,8 @@ void updateLeds(int state) {
 
 void printUsage() {
   Serial.println(F("Commands:"));
+  Serial.println(F("  CONTROL ON  - enable serial control"));
+  Serial.println(F("  CONTROL OFF - disable serial control"));
   Serial.println(F("  D3 HIGH/LOW"));
   Serial.println(F("  D4 HIGH/LOW"));
   Serial.println(F("  D5 HIGH/LOW"));
@@ -83,17 +89,23 @@ void handleSerial() {
       Serial.print(digitalRead(ledPins[1]) ? "HIGH" : "LOW");
       Serial.print(" D5=");
       Serial.println(digitalRead(ledPins[2]) ? "HIGH" : "LOW");
-    } else if (cmd.startsWith("D3 ")) {
+    } else if (cmd == "CONTROL ON") {
+      serialControl = true;
+      Serial.println(F("Serial control enabled"));
+    } else if (cmd == "CONTROL OFF") {
+      serialControl = false;
+      Serial.println(F("Serial control disabled"));
+    } else if (serialControl && cmd.startsWith("D3 ")) {
       String val = cmd.substring(3);
       val.trim();
       if (val == "HIGH") digitalWrite(ledPins[0], HIGH);
       else if (val == "LOW") digitalWrite(ledPins[0], LOW);
-    } else if (cmd.startsWith("D4 ")) {
+    } else if (serialControl && cmd.startsWith("D4 ")) {
       String val = cmd.substring(3);
       val.trim();
       if (val == "HIGH") digitalWrite(ledPins[1], HIGH);
       else if (val == "LOW") digitalWrite(ledPins[1], LOW);
-    } else if (cmd.startsWith("D5 ")) {
+    } else if (serialControl && cmd.startsWith("D5 ")) {
       String val = cmd.substring(3);
       val.trim();
       if (val == "HIGH") digitalWrite(ledPins[2], HIGH);

--- a/button_sequence.ino
+++ b/button_sequence.ino
@@ -1,5 +1,6 @@
 void updateLeds(int state);
 void handleSerial();
+void printUsage();
 
 const int buttonPin = 2;
 const int ledPins[] = {3, 4, 5};
@@ -9,6 +10,7 @@ bool lastButtonState = HIGH;
 
 void setup() {
   Serial.begin(9600);
+  printUsage();
   pinMode(buttonPin, INPUT_PULLUP);  // D2 as input with pull-up
   for (int i = 0; i < 3; ++i) {
     pinMode(ledPins[i], OUTPUT);
@@ -58,6 +60,14 @@ void updateLeds(int state) {
       digitalWrite(ledPins[2], HIGH);
       break;
   }
+}
+
+void printUsage() {
+  Serial.println(F("Commands:"));
+  Serial.println(F("  D3 HIGH/LOW"));
+  Serial.println(F("  D4 HIGH/LOW"));
+  Serial.println(F("  D5 HIGH/LOW"));
+  Serial.println(F("  STATUS - report pin states"));
 }
 
 void handleSerial() {

--- a/button_sequence.ino
+++ b/button_sequence.ino
@@ -1,0 +1,93 @@
+void updateLeds(int state);
+void handleSerial();
+
+const int buttonPin = 2;
+const int ledPins[] = {3, 4, 5};
+
+int currentState = 0; // 0..3
+bool lastButtonState = HIGH;
+
+void setup() {
+  Serial.begin(9600);
+  pinMode(buttonPin, INPUT_PULLUP);  // D2 as input with pull-up
+  for (int i = 0; i < 3; ++i) {
+    pinMode(ledPins[i], OUTPUT);
+    digitalWrite(ledPins[i], LOW);   // D3~D5 start LOW
+  }
+}
+
+void loop() {
+  bool reading = digitalRead(buttonPin);
+
+  // detect button press (transition from HIGH to LOW)
+  if (lastButtonState == HIGH && reading == LOW) {
+    // simple debounce delay
+    delay(50);
+    reading = digitalRead(buttonPin);
+    if (reading == LOW) {
+      currentState = (currentState + 1) % 4;  // cycle states 0..3
+      updateLeds(currentState);
+    }
+  }
+
+  lastButtonState = reading;
+
+  handleSerial();
+}
+
+void updateLeds(int state) {
+  switch (state) {
+    case 0: // D3 HIGH, others LOW
+      digitalWrite(ledPins[0], HIGH);
+      digitalWrite(ledPins[1], LOW);
+      digitalWrite(ledPins[2], LOW);
+      break;
+    case 1: // D4 HIGH, others LOW
+      digitalWrite(ledPins[0], LOW);
+      digitalWrite(ledPins[1], HIGH);
+      digitalWrite(ledPins[2], LOW);
+      break;
+    case 2: // D5 HIGH, others LOW
+      digitalWrite(ledPins[0], LOW);
+      digitalWrite(ledPins[1], LOW);
+      digitalWrite(ledPins[2], HIGH);
+      break;
+    case 3: // all HIGH
+      digitalWrite(ledPins[0], HIGH);
+      digitalWrite(ledPins[1], HIGH);
+      digitalWrite(ledPins[2], HIGH);
+      break;
+  }
+}
+
+void handleSerial() {
+  if (Serial.available()) {
+    String cmd = Serial.readStringUntil('\n');
+    cmd.trim();
+    cmd.toUpperCase();
+
+    if (cmd == "STATUS") {
+      Serial.print("D3=");
+      Serial.print(digitalRead(ledPins[0]) ? "HIGH" : "LOW");
+      Serial.print(" D4=");
+      Serial.print(digitalRead(ledPins[1]) ? "HIGH" : "LOW");
+      Serial.print(" D5=");
+      Serial.println(digitalRead(ledPins[2]) ? "HIGH" : "LOW");
+    } else if (cmd.startsWith("D3 ")) {
+      String val = cmd.substring(3);
+      val.trim();
+      if (val == "HIGH") digitalWrite(ledPins[0], HIGH);
+      else if (val == "LOW") digitalWrite(ledPins[0], LOW);
+    } else if (cmd.startsWith("D4 ")) {
+      String val = cmd.substring(3);
+      val.trim();
+      if (val == "HIGH") digitalWrite(ledPins[1], HIGH);
+      else if (val == "LOW") digitalWrite(ledPins[1], LOW);
+    } else if (cmd.startsWith("D5 ")) {
+      String val = cmd.substring(3);
+      val.trim();
+      if (val == "HIGH") digitalWrite(ledPins[2], HIGH);
+      else if (val == "LOW") digitalWrite(ledPins[2], LOW);
+    }
+  }
+}

--- a/button_sequence.ino
+++ b/button_sequence.ino
@@ -100,7 +100,7 @@ void printUsage() {
   Serial.println(F("Set pin LOW:     SET D3 LOW   (S D3 L)"));
   Serial.println(F("Read single pin: READ D3      (R D3)"));
   Serial.println(F("Read all pins:   READ ALL     (R A)"));
-  Serial.println(F("Toggle control:  CONTROL ON/OFF"));
+  Serial.println(F("Toggle control:  CTL ON/OFF"));
   Serial.println(F("Supported pins:  D2~D9, A0~A5"));
   Serial.println(F("================================================"));
 }
@@ -112,12 +112,12 @@ void handleSerial() {
   cmd.trim();
   cmd.toUpperCase();
 
-  if (cmd == "CONTROL ON") {
+  if (cmd == "CTL ON") {
     serialControl = true;
     Serial.println(F("Serial control enabled"));
     return;
   }
-  if (cmd == "CONTROL OFF") {
+  if (cmd == "CTL OFF") {
     serialControl = false;
     Serial.println(F("Serial control disabled"));
     return;


### PR DESCRIPTION
## Summary
- enable Serial at 9600 bps
- add `handleSerial()` function allowing control of D3–D5 via commands
- print pin states when `STATUS` command received

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6879aceb5bb4832482474fb030a4e02e